### PR TITLE
PAL-566-implement-checkstyle-for-test-code-across-all-repos Palisade-…

### DIFF
--- a/code-style/checkstyle-suppressions.xml
+++ b/code-style/checkstyle-suppressions.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2020 Crown Copyright
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.0//EN"
+        "https://checkstyle.org/dtds/suppressions_1_0.dtd">
+<!-- Exclude any checks on the PathUtils as the copyright notice is a verbatim copy of the one in the original file along with most of the code.  -->
+<suppressions>
+    <suppress checks="RegexpHeader"
+              files="PathUtils.java"/>
+</suppressions>

--- a/hadoop-reader/src/test/java/uk/gov/gchq/palisade/reader/HadoopDataReaderTest.java
+++ b/hadoop-reader/src/test/java/uk/gov/gchq/palisade/reader/HadoopDataReaderTest.java
@@ -143,7 +143,7 @@ public class HadoopDataReaderTest {
         assertEquals(Arrays.asList("some data", "some more data"), lines.collect(Collectors.toList()));
     }
 
-    private static HadoopDataReader getReader(Configuration conf) throws IOException {
+    private static HadoopDataReader getReader(final Configuration conf) throws IOException {
         return new HadoopDataReader().conf(conf);
     }
 }

--- a/hadoop-reader/src/test/java/uk/gov/gchq/palisade/reader/util/PathUtils.java
+++ b/hadoop-reader/src/test/java/uk/gov/gchq/palisade/reader/util/PathUtils.java
@@ -26,19 +26,19 @@ import java.io.File;
 // PathUtils has been copied from Hadoop-HDFS version 2.6.0
 // This was previously presenting some windows/unix compatibility problems
 public class PathUtils {
-    public static Path getTestPath(Class<?> caller) {
+    public static Path getTestPath(final Class<?> caller) {
         return getTestPath(caller, true);
     }
 
-    public static Path getTestPath(Class<?> caller, boolean create) {
+    public static Path getTestPath(final Class<?> caller, final boolean create) {
         return new Path(getTestDirName(caller));
     }
 
-    public static File getTestDir(Class<?> caller) {
+    public static File getTestDir(final Class<?> caller) {
         return getTestDir(caller, true);
     }
 
-    public static File getTestDir(Class<?> caller, boolean create) {
+    public static File getTestDir(final Class<?> caller, final boolean create) {
         File dir = new File(System.getProperty("test.build.data", "target/test/data")
                 + "/" + RandomStringUtils.randomAlphanumeric(10),
                 caller.getSimpleName());
@@ -48,11 +48,11 @@ public class PathUtils {
         return dir;
     }
 
-    public static String getTestDirName(Class<?> caller) {
+    public static String getTestDirName(final Class<?> caller) {
         return getTestDirName(caller, true);
     }
 
-    public static String getTestDirName(Class<?> caller, boolean create) {
+    public static String getTestDirName(final Class<?> caller, final boolean create) {
         return getTestDir(caller, create).getAbsolutePath();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,9 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${checkstyle.plugin.version}</version>
                 <configuration>
+                    <suppressionsLocation>code-style/checkstyle-suppressions.xml</suppressionsLocation>
+                    <suppressionsFileExpression>checkstyle.suppressions.file</suppressionsFileExpression>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <configLocation>code-style/checkstyle.xml</configLocation>
                     <encoding>UTF-8</encoding>
                     <consoleOutput>true</consoleOutput>
@@ -131,15 +134,6 @@
                     <execution>
                         <id>validate</id>
                         <phase>${checkstyle.phase}</phase>
-                        <configuration>
-                            <configLocation>code-style/checkstyle.xml
-                            </configLocation>
-                            <encoding>UTF-8</encoding>
-                            <consoleOutput>true</consoleOutput>
-                            <failsOnError>true</failsOnError>
-                            <headerLocation>code-style/licenseHeader.txt
-                            </headerLocation>
-                        </configuration>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/shade-hadoop-client/README.md
+++ b/shade-hadoop-client/README.md
@@ -1,5 +1,5 @@
 <!---
-Copyright 2019 Crown Copyright
+Copyright 2020 Crown Copyright
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/shade-hadoop-client/README.md
+++ b/shade-hadoop-client/README.md
@@ -1,3 +1,18 @@
+<!---
+Copyright 2019 Crown Copyright
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--->
 # Hadoop Library
 
 This is a Hadoop client library dependency which is used within Palisade. Hadoop contains several dependencies for its own use, which

--- a/shade-hadoop-client/pom.xml
+++ b/shade-hadoop-client/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2018 Crown Copyright
+  ~ Copyright 2020 Crown Copyright
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/shade-hadoop-client/pom.xml
+++ b/shade-hadoop-client/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Crown Copyright
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>uk.gov.gchq.palisade</groupId>


### PR DESCRIPTION
…Readers.

Changes included suppressing the check for copyright notice on the file PathUtils.java.  The file is a copy on some existing code and has an existing notice so this has been excluded from the checks.  